### PR TITLE
head-only formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 ```
 $ brew tap unkontributors/unko
-$ brew install super_unko
+$ brew install --HEAD super_unko
 ```

--- a/super_unko.rb
+++ b/super_unko.rb
@@ -2,8 +2,11 @@ class SuperUnko < Formula
   desc "Let's us create shit commands"
   homepage "https://github.com/greymd/super_unko"
   url "https://github.com/unkontributors/super_unko.git", :branch => "master"
-  head "https://github.com/unkontributors/super_unko.git", :branch => "master"
 
+  head do
+    url "https://github.com/unkontributors/super_unko.git", :branch => "master"
+  end
+    
   bottle :unneeded
 
   def install

--- a/super_unko.rb
+++ b/super_unko.rb
@@ -1,8 +1,7 @@
 class SuperUnko < Formula
   desc "Let's us create shit commands"
   homepage "https://github.com/greymd/super_unko"
-  url "https://github.com/unkontributors/super_unko.git", :branch => "master"
-
+  
   head do
     url "https://github.com/unkontributors/super_unko.git", :branch => "master"
   end


### PR DESCRIPTION
In my environment, following error was raised.

```
$ brew --version
Homebrew 2.2.10
Homebrew/homebrew-core (git revision 9dfa9; last commit 2020-03-11)

$ brew tap unkontributors/unko
Updating Homebrew...
==> Tapping unkontributors/unko
Cloning into '/usr/local/Homebrew/Library/Taps/unkontributors/homebrew-unko'...
remote: Enumerating objects: 4, done.
remote: Total 4 (delta 0), reused 0 (delta 0), pack-reused 4
Unpacking objects: 100% (4/4), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/unkontributors/homebrew-unko/super_unko.rb
invalid attribute for formula 'unkontributors/unko/super_unko': version (nil)
Error: Cannot tap unkontributors/unko: invalid syntax in tap!
```

It might be better if we make this formula "head-only" explicitly and revise the README something like

```
$ brew tap unkontributors/unko
$ brew install --HEAD super_unko
```

In this way, if `--HEAD` option is omitted, following error would be shown.
I guess it's more understandable.

```
Error: super_unko is a head-only formula
Install with `brew install --HEAD super_unko`
```

💩 < I'd be glad if you would consider this change.